### PR TITLE
Feat: User Quests now active.

### DIFF
--- a/src/app/my-quests/page.tsx
+++ b/src/app/my-quests/page.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  listMyUserQuests,
+  completeUserQuest,
+  deleteUserQuest,
+  UserQuest,
+  UserQuestCompleteBody,
+  getAuthToken,
+} from "@/lib/api";
+
+export default function MyQuestsPage() {
+  const qc = useQueryClient();
+
+  // token-aware fetch (avoid SSR mismatch)
+  const [hasToken, setHasToken] = useState(false);
+  useEffect(() => setHasToken(!!getAuthToken()), []);
+
+  const { data, isLoading, error } = useQuery<UserQuest[]>({
+    queryKey: ["my-user-quests"],
+    queryFn: listMyUserQuests,
+    enabled: hasToken, // only fetch when we have a token
+  });
+
+  const [tab, setTab] = useState<"inprogress" | "completed">("inprogress");
+
+  const inProgress = useMemo(
+    () => (data ?? []).filter((u) => !u.completed),
+    [data]
+  );
+  const completed = useMemo(
+    () => (data ?? []).filter((u) => u.completed),
+    [data]
+  );
+
+  // Complete modal state
+  const [completeOpen, setCompleteOpen] = useState(false);
+  const [activeUQ, setActiveUQ] = useState<UserQuest | null>(null);
+
+  const completeMut = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: UserQuestCompleteBody }) =>
+      completeUserQuest(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+      setCompleteOpen(false);
+      setActiveUQ(null);
+    },
+  });
+
+  // Cancel (delete) modal state
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [toDelete, setToDelete] = useState<UserQuest | null>(null);
+
+  const deleteMut = useMutation({
+    mutationFn: (id: number) => deleteUserQuest(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+      setConfirmOpen(false);
+      setToDelete(null);
+    },
+  });
+
+  if (!hasToken) {
+    return (
+      <main className="p-6">
+        <h1 className="text-2xl font-bold mb-4">My Quests</h1>
+        <div className="rounded-2xl border p-4 bg-white">
+          Log in to see your quests.
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">My Quests</h1>
+
+        {/* Simple tabs */}
+        <div className="inline-flex rounded-xl border bg-white overflow-hidden">
+          <button
+            onClick={() => setTab("inprogress")}
+            className={`px-4 py-2 text-sm ${
+              tab === "inprogress" ? "bg-emerald-600 text-white" : "bg-white"
+            }`}
+          >
+            In Progress ({inProgress.length})
+          </button>
+          <button
+            onClick={() => setTab("completed")}
+            className={`px-4 py-2 text-sm ${
+              tab === "completed" ? "bg-emerald-600 text-white" : "bg-white"
+            }`}
+          >
+            Completed ({completed.length})
+          </button>
+        </div>
+      </div>
+
+      {isLoading && <div>Loading your quests…</div>}
+      {error && (
+        <div className="rounded-2xl border p-4 bg-white">
+          Couldn’t load your quests.
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <>
+          {tab === "inprogress" ? (
+            <UserQuestList
+              items={inProgress}
+              emptyMsg="No quests in progress yet."
+              renderActions={(u) => (
+                <div className="flex gap-2">
+                  <button
+                    className="px-3 py-1 rounded-xl bg-emerald-600 text-white"
+                    onClick={() => {
+                      setActiveUQ(u);
+                      setCompleteOpen(true);
+                    }}
+                  >
+                    Complete
+                  </button>
+                  <button
+                    className="px-3 py-1 rounded-xl bg-red-100"
+                    onClick={() => {
+                      setToDelete(u);
+                      setConfirmOpen(true);
+                    }}
+                    disabled={deleteMut.isPending && toDelete?.id === u.id}
+                  >
+                    {deleteMut.isPending && toDelete?.id === u.id
+                      ? "Deleting…"
+                      : "Cancel"}
+                  </button>
+                </div>
+              )}
+            />
+          ) : (
+            <UserQuestList
+              items={completed}
+              emptyMsg="No completed quests yet."
+            />
+          )}
+        </>
+      )}
+
+      {/* Complete modal */}
+      <CompleteModal
+        open={completeOpen}
+        onClose={() => {
+          if (!completeMut.isPending) {
+            setCompleteOpen(false);
+            setActiveUQ(null);
+          }
+        }}
+        uq={activeUQ}
+        onSubmit={(body) => {
+          if (!activeUQ) return;
+          completeMut.mutate({ id: activeUQ.id, body });
+        }}
+        submitting={completeMut.isPending}
+        errorMsg={(completeMut.error as any)?.message}
+      />
+
+      {/* Confirm cancel modal */}
+      <ConfirmModal
+        open={confirmOpen}
+        title="Cancel quest?"
+        body="This will remove the in-progress quest from your list."
+        confirmText={deleteMut.isPending ? "Deleting…" : "Yes, cancel it"}
+        cancelText="Nevermind"
+        onCancel={() => {
+          if (!deleteMut.isPending) {
+            setConfirmOpen(false);
+            setToDelete(null);
+          }
+        }}
+        onConfirm={() => {
+          if (toDelete) deleteMut.mutate(toDelete.id);
+        }}
+      />
+    </main>
+  );
+}
+
+function UserQuestList({
+  items,
+  emptyMsg,
+  renderActions,
+}: {
+  items: UserQuest[];
+  emptyMsg: string;
+  renderActions?: (u: UserQuest) => React.ReactNode;
+}) {
+  if (!items.length) {
+    return (
+      <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">
+        {emptyMsg}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {items.map((u) => (
+        <li key={u.id} className="rounded-2xl shadow p-4 bg-white space-y-3">
+          <div className="flex items-center gap-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            {u.quest?.icon?.icon_url && (
+              <img
+                src={u.quest.icon.icon_url}
+                alt={u.quest.icon.name}
+                className="h-8 w-8"
+              />
+            )}
+            <div>
+              <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
+              <p className="text-sm text-gray-500">
+                {u.quest?.category?.name} · {u.quest?.difficulty?.name}
+              </p>
+            </div>
+          </div>
+
+          <p className="text-sm text-gray-700">{u.quest?.description}</p>
+
+          {!!u.quest?.tags?.length && (
+            <div className="flex flex-wrap gap-2">
+              {u.quest.tags.map((t) => (
+                <span
+                  key={t.id}
+                  className="text-xs bg-gray-100 px-2 py-1 rounded-full"
+                >
+                  #{t.name}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Completion metadata (only visible for completed) */}
+          {u.completed && (
+            <div className="text-xs text-gray-500">
+              {u.completed_at ? (
+                <span>Completed at: {new Date(u.completed_at).toLocaleString()}</span>
+              ) : (
+                <span>Completed</span>
+              )}
+              {u.rating != null && (
+                <span className="ml-2">• Rating: {String(u.rating)}</span>
+              )}
+            </div>
+          )}
+
+          {/* Actions (only for in-progress list) */}
+          {!u.completed && renderActions && (
+            <div className="pt-1">{renderActions(u)}</div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/* ===== Modals ===== */
+
+function CompleteModal({
+  open,
+  onClose,
+  uq,
+  onSubmit,
+  submitting,
+  errorMsg,
+}: {
+  open: boolean;
+  onClose: () => void;
+  uq: UserQuest | null;
+  onSubmit: (body: UserQuestCompleteBody) => void;
+  submitting: boolean;
+  errorMsg?: string;
+}) {
+  const [reflection, setReflection] = useState("");
+  const [rating, setRating] = useState("4.5");
+  const [photoUrl, setPhotoUrl] = useState("");
+  const [completedAt, setCompletedAt] = useState("");
+
+  // reset when opening/closing
+  useEffect(() => {
+    if (open) {
+      setReflection("");
+      setRating("4.5");
+      setPhotoUrl("");
+      setCompletedAt("");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open || !uq) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div className="w-full max-w-xl rounded-2xl bg-white shadow-xl p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold">
+              Complete: <span className="font-normal">{uq.quest?.title}</span>
+            </h2>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="p-2 rounded hover:bg-gray-100"
+            >
+              ✕
+            </button>
+          </div>
+
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmit({
+                reflection: reflection.trim(),
+                rating: Number(rating),
+                photo_url: photoUrl.trim() || undefined,
+                completed_at: completedAt.trim() || undefined,
+              });
+            }}
+          >
+            <label className="block">
+              <span className="text-sm text-gray-600">Reflection *</span>
+              <textarea
+                className="w-full border rounded-xl px-3 py-2"
+                rows={3}
+                value={reflection}
+                onChange={(e) => setReflection(e.target.value)}
+                required
+              />
+            </label>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <label className="block">
+                <span className="text-sm text-gray-600">Rating *</span>
+                <input
+                  type="number"
+                  step="0.5"
+                  min="1"
+                  max="5"
+                  className="w-full border rounded-xl px-3 py-2"
+                  value={rating}
+                  onChange={(e) => setRating(e.target.value)}
+                  required
+                />
+              </label>
+              <label className="block md:col-span-2">
+                <span className="text-sm text-gray-600">Photo URL (optional)</span>
+                <input
+                  className="w-full border rounded-xl px-3 py-2"
+                  value={photoUrl}
+                  onChange={(e) => setPhotoUrl(e.target.value)}
+                  placeholder="https://…"
+                />
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="text-sm text-gray-600">Completed At (optional ISO)</span>
+              <input
+                className="w-full border rounded-xl px-3 py-2"
+                value={completedAt}
+                onChange={(e) => setCompletedAt(e.target.value)}
+                placeholder="2025-08-13T10:30:00-05:00"
+              />
+            </label>
+
+            {errorMsg && (
+              <p className="text-sm text-red-600">{errorMsg}</p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="px-4 py-2 rounded-xl bg-gray-100"
+                onClick={onClose}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-xl bg-emerald-600 text-white"
+                disabled={submitting}
+              >
+                {submitting ? "Submitting…" : "Mark Complete"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmModal({
+  open,
+  title,
+  body,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title: string;
+  body?: string;
+  confirmText: string;
+  cancelText: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div className="w-full max-w-md rounded-2xl bg-white shadow-xl p-4">
+          <h3 className="text-lg font-semibold mb-2">{title}</h3>
+          {body && <p className="text-sm text-gray-600 mb-4">{body}</p>}
+          <div className="flex justify-end gap-2">
+            <button className="px-4 py-2 rounded-xl bg-gray-100" onClick={onCancel}>
+              {cancelText}
+            </button>
+            <button className="px-4 py-2 rounded-xl bg-red-600 text-white" onClick={onConfirm}>
+              {confirmText}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/quests/page.tsx
+++ b/src/app/quests/page.tsx
@@ -1,167 +1,3 @@
-// "use client";
-
-// import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-// import { API, Quest, QuestPatchBody,  QuestCreateBody, Category, Icon, Difficulty, Tag, getAuthToken } from "@/lib/api";
-// import { useState } from "react";
-
-// export default function QuestsPage() {
-//   const qc = useQueryClient();
-
-//   // fetch quests (public GET)
-//   const { data: quests, isLoading, error } = useQuery<Quest[]>({
-//     queryKey: ["quests"],
-//     queryFn: API.listQuests,
-//   });
-
-//   // fetch current user only if we have a token
-//   const hasToken = typeof window !== "undefined" && !!getAuthToken();
-//   const { data: me } = useQuery({
-//     queryKey: ["me"],
-//     queryFn: API.me,
-//     enabled: hasToken,
-//   });
-
-//   // mutations
-//   const deleteMut = useMutation({
-//     mutationFn: (id: number) => API.deleteQuest(id),
-//     onSuccess: () => qc.invalidateQueries({ queryKey: ["quests"] }),
-//   });
-
-//   const patchMut = useMutation({
-//     mutationFn: ({ id, body }: { id: number; body: Partial<QuestPatchBody> }) =>
-//       API.patchQuest(id, body),
-//     onSuccess: () => qc.invalidateQueries({ queryKey: ["quests"] }),
-//   });
-
-//   if (isLoading) return <div className="p-6">Loading quests…</div>;
-//   if (error) return <div className="p-6">Couldn’t load quests.</div>;
-
-//   return (
-//     <main className="p-6 space-y-4">
-//       <h1 className="text-2xl font-bold">EcoGrow Quests</h1>
-
-//       <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-//         {quests?.map((q) => {
-//           const canEdit = !!me && me.id === q.created_by;
-//           return (
-//             <QuestCard
-//               key={q.id}
-//               q={q}
-//               canEdit={canEdit}
-//               onDelete={() => deleteMut.mutate(q.id)}
-//               onSave={(body) => patchMut.mutate({ id: q.id, body })}
-//               saving={patchMut.isPending}
-//               deleting={deleteMut.isPending}
-//             />
-//           );
-//         })}
-//       </ul>
-//     </main>
-//   );
-// }
-
-// function QuestCard({
-//   q,
-//   canEdit,
-//   onDelete,
-//   onSave,
-//   saving,
-//   deleting,
-// }: {
-//   q: Quest;
-//   canEdit: boolean;
-//   onDelete: () => void;
-//   onSave: (body: Partial<QuestPatchBody>) => void;
-//   saving: boolean;
-//   deleting: boolean;
-// }) {
-//   const [editing, setEditing] = useState(false);
-//   const [title, setTitle] = useState(q.title);
-//   const [description, setDescription] = useState(q.description || "");
-
-//   return (
-//     <li className="rounded-2xl shadow p-4 bg-white space-y-3">
-//       <div className="flex items-center gap-3">
-//         {/* eslint-disable-next-line @next/next/no-img-element */}
-//         {q.icon?.icon_url && <img src={q.icon.icon_url} alt={q.icon.name} className="h-8 w-8" />}
-//         <div>
-//           <h2 className="text-lg font-semibold">{q.title}</h2>
-//           <p className="text-sm text-gray-500">{q.category?.name} · {q.difficulty?.name}</p>
-//         </div>
-//       </div>
-
-//       {editing ? (
-//         <>
-//           <input
-//             className="w-full border rounded-xl px-3 py-2"
-//             value={title}
-//             onChange={(e) => setTitle(e.target.value)}
-//             placeholder="Title"
-//           />
-//           <textarea
-//             className="w-full border rounded-xl px-3 py-2"
-//             value={description}
-//             onChange={(e) => setDescription(e.target.value)}
-//             placeholder="Description"
-//             rows={3}
-//           />
-//           <div className="flex gap-2">
-//             <button
-//               className="px-3 py-1 rounded-xl bg-emerald-100"
-//               onClick={() => {
-//                 onSave({ title, description });
-//                 setEditing(false);
-//               }}
-//               disabled={saving}
-//             >
-//               {saving ? "Saving…" : "Save"}
-//             </button>
-//             <button
-//               className="px-3 py-1 rounded-xl bg-gray-100"
-//               onClick={() => {
-//                 setTitle(q.title);
-//                 setDescription(q.description || "");
-//                 setEditing(false);
-//               }}
-//             >
-//               Cancel
-//             </button>
-//           </div>
-//         </>
-//       ) : (
-//         <>
-//           <p className="text-sm text-gray-700">{q.description}</p>
-//           {!!q.tags?.length && (
-//             <div className="flex flex-wrap gap-2">
-//               {q.tags.map((t) => (
-//                 <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">#{t.name}</span>
-//               ))}
-//             </div>
-//           )}
-//           {canEdit && (
-//             <div className="flex gap-2">
-//               <button
-//                 className="px-3 py-1 rounded-xl bg-gray-100"
-//                 onClick={() => setEditing(true)}
-//               >
-//                 Edit
-//               </button>
-//               <button
-//                 className="px-3 py-1 rounded-xl bg-red-100"
-//                 onClick={onDelete}
-//                 disabled={deleting}
-//               >
-//                 {deleting ? "Deleting…" : "Delete"}
-//               </button>
-//             </div>
-//           )}
-//         </>
-//       )}
-//     </li>
-//   );
-// }
-
-
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -175,6 +11,10 @@ import {
   Difficulty,
   Tag,
   getAuthToken,
+  // new imports
+  listMyUserQuests,
+  adoptUserQuest,
+  UserQuest,
 } from "@/lib/api";
 import { useEffect, useMemo, useState } from "react";
 
@@ -187,14 +27,30 @@ export default function QuestsPage() {
     queryFn: API.listQuests,
   });
 
-  // fetch current user only if we have a token
+  // auth presence
   const [hasToken, setHasToken] = useState(false);
-  useEffect(() => { setHasToken(!!getAuthToken()); }, []);
+  useEffect(() => {
+    setHasToken(!!getAuthToken());
+  }, []);
+
+  // current user (only when logged in)
   const { data: me } = useQuery({
     queryKey: ["me"],
     queryFn: API.me,
     enabled: hasToken,
   });
+
+  // my active user_quests to prevent duplicate undertaking
+  const { data: myUserQuests = [] } = useQuery<UserQuest[]>({
+    queryKey: ["my-user-quests"],
+    queryFn: listMyUserQuests,
+    enabled: hasToken,
+  });
+
+  // set of quest IDs already in progress for me
+  const inProgressSet = useMemo(() => {
+    return new Set(myUserQuests.filter((u) => !u.completed).map((u) => u.quest.id));
+  }, [myUserQuests]);
 
   // dropdown data
   const { data: categories = [], isLoading: catLoading } = useQuery<Category[]>({
@@ -229,6 +85,21 @@ export default function QuestsPage() {
   const createMut = useMutation({
     mutationFn: (body: QuestCreateBody) => API.createQuest(body),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["quests"] }),
+  });
+
+  // NEW: undertake (adopt) mutation
+  const [adoptingId, setAdoptingId] = useState<number | null>(null);
+  const adoptMut = useMutation({
+    mutationFn: (questId: number) => adoptUserQuest(questId),
+    onMutate: (qid) => setAdoptingId(qid),
+    onError: (e: any) => {
+      alert(e?.message || "Could not undertake this quest.");
+    },
+    onSuccess: () => {
+      // refresh my-user-quests so /my-quests shows it immediately
+      qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+    },
+    onSettled: () => setAdoptingId(null),
   });
 
   // modal state
@@ -273,6 +144,9 @@ export default function QuestsPage() {
       <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {quests?.map((q) => {
           const canEdit = !!me && me.id === q.created_by;
+          const canUndertake = hasToken && !inProgressSet.has(q.id);
+          const undertaking = adoptingId === q.id;
+
           return (
             <QuestCard
               key={q.id}
@@ -282,6 +156,10 @@ export default function QuestsPage() {
               onSave={(body) => patchMut.mutate({ id: q.id, body })}
               saving={patchMut.isPending}
               deleting={deleteMut.isPending}
+              // new props
+              canUndertake={canUndertake}
+              undertaking={undertaking}
+              onUndertake={() => adoptMut.mutate(q.id)}
             />
           );
         })}
@@ -313,7 +191,9 @@ function CreateQuestModal({
 }) {
   useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onClose]);
@@ -537,6 +417,10 @@ function QuestCard({
   onSave,
   saving,
   deleting,
+  // new props
+  canUndertake,
+  undertaking,
+  onUndertake,
 }: {
   q: Quest;
   canEdit: boolean;
@@ -544,6 +428,10 @@ function QuestCard({
   onSave: (body: Partial<QuestPatchBody>) => void;
   saving: boolean;
   deleting: boolean;
+  // new props
+  canUndertake: boolean;
+  undertaking: boolean;
+  onUndertake: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [title, setTitle] = useState(q.title);
@@ -617,23 +505,39 @@ function QuestCard({
               ))}
             </div>
           )}
-          {canEdit && (
-            <div className="flex gap-2">
+
+          <div className="flex gap-2">
+            {/* Undertake button (shown when logged in and not already in progress) */}
+            {canUndertake && (
               <button
-                className="px-3 py-1 rounded-xl bg-gray-100"
-                onClick={() => setEditing(true)}
+                className="px-3 py-1 rounded-xl bg-emerald-600 text-white"
+                onClick={onUndertake}
+                disabled={undertaking}
+                title="Add this quest to My Quests"
               >
-                Edit
+                {undertaking ? "Undertaking…" : "Undertake Quest"}
               </button>
-              <button
-                className="px-3 py-1 rounded-xl bg-red-100"
-                onClick={onDelete}
-                disabled={deleting}
-              >
-                {deleting ? "Deleting…" : "Delete"}
-              </button>
-            </div>
-          )}
+            )}
+
+            {/* Owner controls */}
+            {canEdit && (
+              <>
+                <button
+                  className="px-3 py-1 rounded-xl bg-gray-100"
+                  onClick={() => setEditing(true)}
+                >
+                  Edit
+                </button>
+                <button
+                  className="px-3 py-1 rounded-xl bg-red-100"
+                  onClick={onDelete}
+                  disabled={deleting}
+                >
+                  {deleting ? "Deleting…" : "Delete"}
+                </button>
+              </>
+            )}
+          </div>
         </>
       )}
     </li>

--- a/src/app/tests/my-quests-test/page.tsx
+++ b/src/app/tests/my-quests-test/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import {
+  listMyUserQuests,
+  adoptUserQuest,
+  completeUserQuest,
+  deleteUserQuest,
+  UserQuestCompleteBody,
+} from "@/lib/api";
+
+export default function MyQuestsTestPage() {
+  const [out, setOut] = useState<any>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  // inputs
+  const [adoptQuestId, setAdoptQuestId] = useState<string>("1");
+  const [userQuestId, setUserQuestId] = useState<string>("");
+  const [reflection, setReflection] = useState("");
+  const [rating, setRating] = useState<string>("4.5");
+  const [photoUrl, setPhotoUrl] = useState("");
+  const [completedAt, setCompletedAt] = useState(""); // optional ISO
+
+  async function run<T>(fn: () => Promise<T>) {
+    setErr(null);
+    setOut(null);
+    try {
+      const res = await fn();
+      setOut(res);
+    } catch (e: any) {
+      setErr(e?.message ?? String(e));
+    }
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-bold">UserQuests API Test</h1>
+
+      <div className="rounded-xl border p-4 space-y-3">
+        <h2 className="font-semibold">1) List My UserQuests</h2>
+        <button
+          className="px-3 py-2 rounded bg-emerald-600 text-white"
+          onClick={() => run(() => listMyUserQuests())}
+        >
+          GET /api/user-quests/
+        </button>
+      </div>
+
+      <div className="rounded-xl border p-4 space-y-3">
+        <h2 className="font-semibold">2) Adopt (create in-progress)</h2>
+        <label className="block">
+          <span className="text-sm text-gray-600">Quest ID</span>
+          <input
+            className="border rounded px-3 py-2 w-40"
+            value={adoptQuestId}
+            onChange={(e) => setAdoptQuestId(e.target.value)}
+            inputMode="numeric"
+          />
+        </label>
+        <button
+          className="px-3 py-2 rounded bg-emerald-600 text-white"
+          onClick={() => run(() => adoptUserQuest(Number(adoptQuestId)))}
+        >
+          POST /api/user-quests/
+        </button>
+      </div>
+
+      <div className="rounded-xl border p-4 space-y-3">
+        <h2 className="font-semibold">3) Complete</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="block">
+            <span className="text-sm text-gray-600">UserQuest ID</span>
+            <input
+              className="border rounded px-3 py-2 w-full"
+              value={userQuestId}
+              onChange={(e) => setUserQuestId(e.target.value)}
+              inputMode="numeric"
+              placeholder="e.g. 7"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm text-gray-600">Rating (1–5, half steps)</span>
+            <input
+              type="number"
+              step="0.5"
+              min="1"
+              max="5"
+              className="border rounded px-3 py-2 w-full"
+              value={rating}
+              onChange={(e) => setRating(e.target.value)}
+            />
+          </label>
+        </div>
+        <label className="block">
+          <span className="text-sm text-gray-600">Reflection *</span>
+          <textarea
+            className="border rounded px-3 py-2 w-full"
+            rows={3}
+            value={reflection}
+            onChange={(e) => setReflection(e.target.value)}
+            placeholder="What did you learn/feel?"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-gray-600">Photo URL (optional)</span>
+          <input
+            className="border rounded px-3 py-2 w-full"
+            value={photoUrl}
+            onChange={(e) => setPhotoUrl(e.target.value)}
+            placeholder="https://…"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-gray-600">Completed At (optional ISO)</span>
+          <input
+            className="border rounded px-3 py-2 w-full"
+            value={completedAt}
+            onChange={(e) => setCompletedAt(e.target.value)}
+            placeholder="2025-08-13T10:30:00-05:00"
+          />
+        </label>
+        <button
+          className="px-3 py-2 rounded bg-emerald-600 text-white"
+          onClick={() =>
+            run(() =>
+              completeUserQuest(Number(userQuestId), {
+                reflection: reflection.trim(),
+                rating: Number(rating),
+                photo_url: photoUrl.trim() || undefined,
+                completed_at: completedAt.trim() || undefined,
+              } as UserQuestCompleteBody)
+            )
+          }
+        >
+          POST /api/user-quests/:id/complete/
+        </button>
+      </div>
+
+      <div className="rounded-xl border p-4 space-y-3">
+        <h2 className="font-semibold">4) Cancel (delete in-progress)</h2>
+        <label className="block">
+          <span className="text-sm text-gray-600">UserQuest ID</span>
+          <input
+            className="border rounded px-3 py-2 w-40"
+            value={userQuestId}
+            onChange={(e) => setUserQuestId(e.target.value)}
+            inputMode="numeric"
+          />
+        </label>
+        <button
+          className="px-3 py-2 rounded bg-red-600 text-white"
+          onClick={() => run(() => deleteUserQuest(Number(userQuestId)))}
+        >
+          DELETE /api/user-quests/:id/
+        </button>
+      </div>
+
+      {(err || out) && (
+        <section className="rounded-xl border p-3 bg-white">
+          <h3 className="font-medium">Result</h3>
+          {err ? (
+            <pre className="text-sm text-red-600 whitespace-pre-wrap">{err}</pre>
+          ) : (
+            <pre className="text-sm whitespace-pre-wrap">
+              {JSON.stringify(out, null, 2)}
+            </pre>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -33,9 +33,8 @@ export default function NavBar() {
         <Link href="/" className="font-medium">EcoGrow</Link>
         <div className="flex items-center gap-4">
           <Link href="/" className="hover:underline">Home</Link>
-          <Link href="/quests" className="px-3 py-2 rounded-xl hover:bg-gray-100">
-  Quests
-</Link>
+          <Link href="/quests" className="px-3 py-2 rounded-xl hover:bg-gray-100">Quests</Link>
+          <Link href="/my-quests" className="px-3 py-2 rounded-xl hover:bg-gray-100"> My Quests</Link>
           <button
             onClick={onLogout}
             className="rounded-md border px-3 py-1 text-sm"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -84,6 +84,45 @@ export type QuestCreateBody = {
   tag_ids?: number[]; // optional, up to 3 on the UI
 };
 
+// ===== UserQuest Types =====
+export type UserQuest = {
+  id: number;
+  quest: Quest;                         // nested quest comes back from the API
+  completed: boolean;
+  completed_at: string | null;          // ISO string or null
+  reflection: string;
+  photo_url: string;
+  rating: number | string | null;       // DRF may serialize Decimal as string
+};
+
+export type UserQuestCompleteBody = {
+  reflection: string;                   // required
+  rating: number;                       // 1–5 in 0.5 steps
+  photo_url?: string;                   // optional
+  completed_at?: string;                // optional ISO timestamp from client
+};
+
+// ===== UserQuest API (standalone exports) =====
+// (Using standalone exports so you don't have to re-open the API object)
+export const listMyUserQuests = () =>
+  fetchJSON<UserQuest[]>("/api/user-quests/");
+
+export const adoptUserQuest = (quest_id: number) =>
+  fetchJSON<UserQuest>("/api/user-quests/", {
+    method: "POST",
+    body: JSON.stringify({ quest_id }),
+  });
+
+export const completeUserQuest = (id: number, body: UserQuestCompleteBody) =>
+  fetchJSON<UserQuest>(`/api/user-quests/${id}/complete/`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+export const deleteUserQuest = (id: number) =>
+  fetchJSON<void>(`/api/user-quests/${id}/`, { method: "DELETE" });
+
+
 // ===== API surface =====
 export const API = {
   me: () => fetchJSON<Me>("/api/auth/me/"),


### PR DESCRIPTION
# Feat: My Quests + Undertake from Quests

## Summary
Adds a complete **My Quests** experience and lets users **undertake** quests directly from the main Quests page.

- New `/my-quests` page with **In Progress / Completed** tabs
- **Complete** modal (reflection & rating required; photo URL optional; optional client timestamp)
- **Cancel** confirm modal (delete in-progress)
- **Undertake Quest** button on `/quests` for logged-in users
- Navbar link to **My Quests**
- React Query cache updates so views stay fresh

---

## What’s Included

### API Helpers (`src/lib/api.ts`)
- Types:
  - `UserQuest`
  - `UserQuestCompleteBody`
- Functions:
  - `listMyUserQuests()`
  - `adoptUserQuest(quest_id: number)`
  - `completeUserQuest(id: number, body: UserQuestCompleteBody)`
  - `deleteUserQuest(id: number)`

These use the existing `fetchJSON` + token header (`Authorization: Token <EG_TOKEN>`).

### Pages
- **`src/app/my-quests/page.tsx`** (new)
  - Token-aware fetch (`getAuthToken`)
  - Tabs: **In Progress** / **Completed**
  - Cards mirror quest cards; completed shows date + rating
  - **Complete** modal:
    - fields: `reflection` (required), `rating` (1–5, step 0.5, required), `photo_url` (optional), `completed_at` (optional ISO)
    - on submit → calls `completeUserQuest` and invalidates `["my-user-quests"]`
  - **Cancel** modal:
    - confirms then calls `deleteUserQuest`, invalidates `["my-user-quests"]`

- **`src/app/quests/page.tsx`** (updated)
  - Shows **Undertake Quest** button for logged-in users
  - Button disabled if user already has that quest **in progress**
    - Uses `listMyUserQuests()` to build a set of active quest IDs
  - On click → `adoptUserQuest(quest.id)` then invalidates `["my-user-quests"]`
  - Existing Create/Edit/Delete quest functionality preserved

### Navbar
- Add a **My Quests** link pointing to `/my-quests`

---

## How to Test (Manual)

1) **Login**
   - Visit `/login` and log in. Confirm token exists:
     - DevTools → `localStorage.getItem("EG_TOKEN")` should be non-empty.

2) **Undertake from Quests**
   - Go to `/quests`
   - Click **Undertake Quest** on a card
   - Button should disable for that quest (already in progress)

3) **My Quests page**
   - Go to `/my-quests`
   - In **In Progress**, you should see the newly adopted quest

4) **Complete**
   - Click **Complete**
   - Fill **reflection** and **rating** (use 4.5 to confirm half-step works), optional **photo URL** and optional **completed_at**
   - Submit → item moves to **Completed** tab; shows timestamp + rating

5) **Cancel**
   - Adopt another quest
   - In `/my-quests` → **In Progress** → click **Cancel** → confirm
   - Item should disappear from In Progress

---

## Configuration / Env
- Uses `NEXT_PUBLIC_BACKEND_URL` (defaults to `http://127.0.0.1:8000`)
- Auth token key: `EG_TOKEN` in `localStorage`
- Auth header format: `Authorization: Token <token>`

---

## Files Touched (High Level)
- `src/lib/api.ts` — add UserQuest types & helpers
- `src/app/my-quests/page.tsx` — new page with tabs, modals, actions
- `src/app/quests/page.tsx` — add Undertake button + my-user-quests awareness
- Navbar component/layout — add **My Quests** link

---

## Notes / Limitations
- Photo is a **URL field** (no file uploads yet)
- No editing of reflection/rating after completion (MVP)
- No pagination (MVP)
