### PR TITLE
Fix: Updated Quest Cards.

### DIFF
--- a/src/app/my-quests/page.tsx
+++ b/src/app/my-quests/page.tsx
@@ -11,17 +11,39 @@ import {
   getAuthToken,
 } from "@/lib/api";
 
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || "http://127.0.0.1:8000";
+
+async function patchUserQuestLocal(
+  id: number,
+  body: { reflection?: string; rating?: number }
+): Promise<UserQuest> {
+  const token = getAuthToken();
+  const res = await fetch(`${BACKEND_URL}/api/user-quests/${id}/`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Token ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 export default function MyQuestsPage() {
   const qc = useQueryClient();
 
-  // token-aware fetch (avoid SSR mismatch)
   const [hasToken, setHasToken] = useState(false);
   useEffect(() => setHasToken(!!getAuthToken()), []);
 
   const { data, isLoading, error } = useQuery<UserQuest[]>({
     queryKey: ["my-user-quests"],
     queryFn: listMyUserQuests,
-    enabled: hasToken, // only fetch when we have a token
+    enabled: hasToken,
   });
 
   const [tab, setTab] = useState<"inprogress" | "completed">("inprogress");
@@ -35,7 +57,6 @@ export default function MyQuestsPage() {
     [data]
   );
 
-  // Complete modal state
   const [completeOpen, setCompleteOpen] = useState(false);
   const [activeUQ, setActiveUQ] = useState<UserQuest | null>(null);
 
@@ -49,7 +70,19 @@ export default function MyQuestsPage() {
     },
   });
 
-  // Cancel (delete) modal state
+  const [editOpen, setEditOpen] = useState(false);
+  const [editingUQ, setEditingUQ] = useState<UserQuest | null>(null);
+
+  const editMut = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: { reflection?: string; rating?: number } }) =>
+      patchUserQuestLocal(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+      setEditOpen(false);
+      setEditingUQ(null);
+    },
+  });
+
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [toDelete, setToDelete] = useState<UserQuest | null>(null);
 
@@ -66,9 +99,7 @@ export default function MyQuestsPage() {
     return (
       <main className="p-6">
         <h1 className="text-2xl font-bold mb-4">My Quests</h1>
-        <div className="rounded-2xl border p-4 bg-white">
-          Log in to see your quests.
-        </div>
+        <div className="rounded-2xl border p-4 bg-white">Log in to see your quests.</div>
       </main>
     );
   }
@@ -77,22 +108,16 @@ export default function MyQuestsPage() {
     <main className="p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">My Quests</h1>
-
-        {/* Simple tabs */}
         <div className="inline-flex rounded-xl border bg-white overflow-hidden">
           <button
             onClick={() => setTab("inprogress")}
-            className={`px-4 py-2 text-sm ${
-              tab === "inprogress" ? "bg-emerald-600 text-white" : "bg-white"
-            }`}
+            className={`px-4 py-2 text-sm ${tab === "inprogress" ? "bg-emerald-600 text-white" : "bg-white"}`}
           >
             In Progress ({inProgress.length})
           </button>
           <button
             onClick={() => setTab("completed")}
-            className={`px-4 py-2 text-sm ${
-              tab === "completed" ? "bg-emerald-600 text-white" : "bg-white"
-            }`}
+            className={`px-4 py-2 text-sm ${tab === "completed" ? "bg-emerald-600 text-white" : "bg-white"}`}
           >
             Completed ({completed.length})
           </button>
@@ -100,54 +125,42 @@ export default function MyQuestsPage() {
       </div>
 
       {isLoading && <div>Loading your quests…</div>}
-      {error && (
-        <div className="rounded-2xl border p-4 bg-white">
-          Couldn’t load your quests.
-        </div>
-      )}
+      {error && <div className="rounded-2xl border p-4 bg-white">Couldn’t load your quests.</div>}
 
       {!isLoading && !error && (
         <>
           {tab === "inprogress" ? (
-            <UserQuestList
+            <InProgressList
               items={inProgress}
-              emptyMsg="No quests in progress yet."
-              renderActions={(u) => (
-                <div className="flex gap-2">
-                  <button
-                    className="px-3 py-1 rounded-xl bg-emerald-600 text-white"
-                    onClick={() => {
-                      setActiveUQ(u);
-                      setCompleteOpen(true);
-                    }}
-                  >
-                    Complete
-                  </button>
-                  <button
-                    className="px-3 py-1 rounded-xl bg-red-100"
-                    onClick={() => {
-                      setToDelete(u);
-                      setConfirmOpen(true);
-                    }}
-                    disabled={deleteMut.isPending && toDelete?.id === u.id}
-                  >
-                    {deleteMut.isPending && toDelete?.id === u.id
-                      ? "Deleting…"
-                      : "Cancel"}
-                  </button>
-                </div>
-              )}
+              onOpenComplete={(u) => {
+                setActiveUQ(u);
+                setCompleteOpen(true);
+              }}
+              onOpenCancel={(u) => {
+                setToDelete(u);
+                setConfirmOpen(true);
+              }}
+              deletingId={toDelete?.id}
+              isDeleting={deleteMut.isPending}
             />
           ) : (
-            <UserQuestList
+            <CompletedList
               items={completed}
-              emptyMsg="No completed quests yet."
+              onOpenEdit={(u) => {
+                setEditingUQ(u);
+                setEditOpen(true);
+              }}
+              onOpenDelete={(u) => {
+                setToDelete(u);
+                setConfirmOpen(true);
+              }}
+              deletingId={toDelete?.id}
+              isDeleting={deleteMut.isPending}
             />
           )}
         </>
       )}
 
-      {/* Complete modal */}
       <CompleteModal
         open={completeOpen}
         onClose={() => {
@@ -165,12 +178,28 @@ export default function MyQuestsPage() {
         errorMsg={(completeMut.error as any)?.message}
       />
 
-      {/* Confirm cancel modal */}
+      <EditCompletedModal
+        open={editOpen}
+        onClose={() => {
+          if (!editMut.isPending) {
+            setEditOpen(false);
+            setEditingUQ(null);
+          }
+        }}
+        uq={editingUQ}
+        onSubmit={(body) => {
+          if (!editingUQ) return;
+          editMut.mutate({ id: editingUQ.id, body });
+        }}
+        submitting={editMut.isPending}
+        errorMsg={(editMut.error as any)?.message}
+      />
+
       <ConfirmModal
         open={confirmOpen}
-        title="Cancel quest?"
-        body="This will remove the in-progress quest from your list."
-        confirmText={deleteMut.isPending ? "Deleting…" : "Yes, cancel it"}
+        title="Remove this quest?"
+        body="This will delete the quest from your list."
+        confirmText={deleteMut.isPending ? "Deleting…" : "Yes, delete it"}
         cancelText="Nevermind"
         onCancel={() => {
           if (!deleteMut.isPending) {
@@ -186,84 +215,179 @@ export default function MyQuestsPage() {
   );
 }
 
-function UserQuestList({
+/* === Lists === */
+
+function InProgressList({
   items,
-  emptyMsg,
-  renderActions,
+  onOpenComplete,
+  onOpenCancel,
+  isDeleting,
+  deletingId,
 }: {
   items: UserQuest[];
-  emptyMsg: string;
-  renderActions?: (u: UserQuest) => React.ReactNode;
+  onOpenComplete: (u: UserQuest) => void;
+  onOpenCancel: (u: UserQuest) => void;
+  isDeleting: boolean;
+  deletingId?: number;
 }) {
   if (!items.length) {
-    return (
-      <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">
-        {emptyMsg}
-      </div>
-    );
+    return <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">No quests in progress yet.</div>;
   }
 
   return (
     <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {items.map((u) => (
-        <li key={u.id} className="rounded-2xl shadow p-4 bg-white space-y-3">
-          <div className="flex items-center gap-3">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            {u.quest?.icon?.icon_url && (
-              <img
-                src={u.quest.icon.icon_url}
-                alt={u.quest.icon.name}
-                className="h-8 w-8"
-              />
+      {items.map((u) => {
+        const deleting = isDeleting && deletingId === u.id;
+        return (
+          <li key={u.id} className="relative rounded-2xl shadow p-4 bg-white space-y-3">
+            <div className="absolute top-3 right-3 flex gap-2">
+              <button
+                className="px-3 py-1 rounded-xl bg-emerald-600 text-white"
+                onClick={() => onOpenComplete(u)}
+              >
+                Complete
+              </button>
+              <button
+                className="px-3 py-1 rounded-xl bg-red-100"
+                onClick={() => onOpenCancel(u)}
+                disabled={deleting}
+                title="Cancel this in-progress quest"
+              >
+                {deleting ? "Deleting…" : "Cancel"}
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3 pr-28 md:pr-40">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              {u.quest?.icon?.icon_url && (
+                <img src={u.quest.icon.icon_url} alt={u.quest.icon.name} className="h-8 w-8" />
+              )}
+              <div>
+                <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
+                <p className="text-sm text-gray-500">
+                  {u.quest?.category?.name} · {u.quest?.difficulty?.name}
+                </p>
+              </div>
+            </div>
+
+            <p className="text-sm text-gray-700">{u.quest?.description}</p>
+
+            {!!u.quest?.tags?.length && (
+              <div className="flex flex-wrap gap-2">
+                {u.quest.tags.map((t) => (
+                  <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
+                    #{t.name}
+                  </span>
+                ))}
+              </div>
             )}
-            <div>
-              <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
-              <p className="text-sm text-gray-500">
-                {u.quest?.category?.name} · {u.quest?.difficulty?.name}
-              </p>
-            </div>
-          </div>
-
-          <p className="text-sm text-gray-700">{u.quest?.description}</p>
-
-          {!!u.quest?.tags?.length && (
-            <div className="flex flex-wrap gap-2">
-              {u.quest.tags.map((t) => (
-                <span
-                  key={t.id}
-                  className="text-xs bg-gray-100 px-2 py-1 rounded-full"
-                >
-                  #{t.name}
-                </span>
-              ))}
-            </div>
-          )}
-
-          {/* Completion metadata (only visible for completed) */}
-          {u.completed && (
-            <div className="text-xs text-gray-500">
-              {u.completed_at ? (
-                <span>Completed at: {new Date(u.completed_at).toLocaleString()}</span>
-              ) : (
-                <span>Completed</span>
-              )}
-              {u.rating != null && (
-                <span className="ml-2">• Rating: {String(u.rating)}</span>
-              )}
-            </div>
-          )}
-
-          {/* Actions (only for in-progress list) */}
-          {!u.completed && renderActions && (
-            <div className="pt-1">{renderActions(u)}</div>
-          )}
-        </li>
-      ))}
+          </li>
+        );
+      })}
     </ul>
   );
 }
 
-/* ===== Modals ===== */
+function CompletedList({
+  items,
+  onOpenEdit,
+  onOpenDelete,
+  isDeleting,
+  deletingId,
+}: {
+  items: UserQuest[];
+  onOpenEdit: (u: UserQuest) => void;
+  onOpenDelete: (u: UserQuest) => void;
+  isDeleting: boolean;
+  deletingId?: number;
+}) {
+  if (!items.length) {
+    return <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">No completed quests yet.</div>;
+  }
+
+  return (
+    <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {items.map((u) => {
+        const deleting = isDeleting && deletingId === u.id;
+        return (
+          <li key={u.id} className="relative rounded-2xl shadow p-4 bg-white space-y-3">
+            <div className="absolute top-3 right-3 flex gap-2">
+              <button
+                className="px-3 py-1 rounded-xl bg-gray-100"
+                onClick={() => onOpenEdit(u)}
+                title="Edit reflection & rating"
+              >
+                Edit
+              </button>
+              <button
+                className="px-3 py-1 rounded-xl bg-red-100"
+                onClick={() => onOpenDelete(u)}
+                disabled={deleting}
+                title="Delete this completed quest"
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3 pr-28 md:pr-40">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              {u.quest?.icon?.icon_url && (
+                <img src={u.quest.icon.icon_url} alt={u.quest.icon.name} className="h-8 w-8" />
+              )}
+              <div>
+                <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
+                <p className="text-sm text-gray-500">
+                  {u.quest?.category?.name} · {u.quest?.difficulty?.name}
+                </p>
+              </div>
+            </div>
+
+            <p className="text-sm text-gray-700">{u.quest?.description}</p>
+
+            {!!u.quest?.tags?.length && (
+              <div className="flex flex-wrap gap-2">
+                {u.quest.tags.map((t) => (
+                  <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
+                    #{t.name}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {u.photo_url && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={u.photo_url}
+                alt="Proof"
+                className="w-full max-h-56 object-cover rounded-xl border"
+              />
+            )}
+
+            <div className="text-xs text-gray-500">
+              {u.completed_at ? (
+                <span>Completed: {new Date(u.completed_at).toLocaleString()}</span>
+              ) : (
+                <span>Completed</span>
+              )}
+              {u.rating != null && <span className="ml-2">• Rating: {String(u.rating)}</span>}
+            </div>
+
+            {u.reflection && (
+              <div className="rounded-xl bg-gray-50 border p-3">
+                <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+                  Your reflection
+                </div>
+                <p className="text-sm text-gray-800 whitespace-pre-wrap">{u.reflection}</p>
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/* === Modals === */
 
 function CompleteModal({
   open,
@@ -285,7 +409,6 @@ function CompleteModal({
   const [photoUrl, setPhotoUrl] = useState("");
   const [completedAt, setCompletedAt] = useState("");
 
-  // reset when opening/closing
   useEffect(() => {
     if (open) {
       setReflection("");
@@ -315,11 +438,7 @@ function CompleteModal({
             <h2 className="text-lg font-semibold">
               Complete: <span className="font-normal">{uq.quest?.title}</span>
             </h2>
-            <button
-              onClick={onClose}
-              aria-label="Close"
-              className="p-2 rounded hover:bg-gray-100"
-            >
+            <button onClick={onClose} aria-label="Close" className="p-2 rounded hover:bg-gray-100">
               ✕
             </button>
           </div>
@@ -382,25 +501,116 @@ function CompleteModal({
               />
             </label>
 
-            {errorMsg && (
-              <p className="text-sm text-red-600">{errorMsg}</p>
-            )}
+            {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
 
             <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                className="px-4 py-2 rounded-xl bg-gray-100"
-                onClick={onClose}
-                disabled={submitting}
-              >
+              <button type="button" className="px-4 py-2 rounded-xl bg-gray-100" onClick={onClose} disabled={submitting}>
                 Cancel
               </button>
-              <button
-                type="submit"
-                className="px-4 py-2 rounded-xl bg-emerald-600 text-white"
-                disabled={submitting}
-              >
+              <button type="submit" className="px-4 py-2 rounded-xl bg-emerald-600 text-white" disabled={submitting}>
                 {submitting ? "Submitting…" : "Mark Complete"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EditCompletedModal({
+  open,
+  onClose,
+  uq,
+  onSubmit,
+  submitting,
+  errorMsg,
+}: {
+  open: boolean;
+  onClose: () => void;
+  uq: UserQuest | null;
+  onSubmit: (body: { reflection?: string; rating?: number }) => void;
+  submitting: boolean;
+  errorMsg?: string;
+}) {
+  const [reflection, setReflection] = useState("");
+  const [rating, setRating] = useState("4.5");
+
+  useEffect(() => {
+    if (open && uq) {
+      setReflection(uq.reflection || "");
+      setRating(uq.rating != null ? String(uq.rating) : "4.5");
+    }
+  }, [open, uq]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open || !uq) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div className="w-full max-w-xl rounded-2xl bg-white shadow-xl p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold">
+              Edit: <span className="font-normal">{uq.quest?.title}</span>
+            </h2>
+            <button onClick={onClose} aria-label="Close" className="p-2 rounded hover:bg-gray-100">
+              ✕
+            </button>
+          </div>
+
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmit({
+                reflection: reflection.trim(),
+                rating: Number(rating),
+              });
+            }}
+          >
+            <label className="block">
+              <span className="text-sm text-gray-600">Reflection *</span>
+              <textarea
+                className="w-full border rounded-xl px-3 py-2"
+                rows={3}
+                value={reflection}
+                onChange={(e) => setReflection(e.target.value)}
+                required
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-sm text-gray-600">Rating *</span>
+              <input
+                type="number"
+                step="0.5"
+                min="1"
+                max="5"
+                className="w-full border rounded-xl px-3 py-2"
+                value={rating}
+                onChange={(e) => setRating(e.target.value)}
+                required
+              />
+            </label>
+
+            {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
+
+            <div className="flex justify-end gap-2">
+              <button type="button" className="px-4 py-2 rounded-xl bg-gray-100" onClick={onClose} disabled={submitting}>
+                Cancel
+              </button>
+              <button type="submit" className="px-4 py-2 rounded-xl bg-emerald-600 text-white" disabled={submitting}>
+                {submitting ? "Saving…" : "Save Changes"}
               </button>
             </div>
           </form>


### PR DESCRIPTION
# My Quests UX: top-right actions, edit completed, render fix, show reflection + quest text

## Summary
Improves the **My Quests** page for a cleaner experience:
- **Top-right action bar** on cards:
  - In-progress: **Complete**, **Cancel**
  - Completed: **Edit**, **Delete**
- New **Edit Completed** modal to update reflection/rating after completion.
- Cards show **quest description** and (when completed) the **user reflection**.
- Prevent action buttons from overlapping titles with responsive right padding.

## Changes
- `app/my-quests/page.tsx`
  - Conditional rendering per tab; accurate counts.
  - Complete modal (unchanged API) and **Edit Completed** modal (PATCH).
  - Consistent action bar placement (`absolute top-3 right-3`) + title row padding (`pr-28 md:pr-40`).
  - Delete flows confirmed via modal; completed UserQuests can be removed.

## API Touchpoints
- `POST /api/user-quests/{id}/complete/`
- `PATCH /api/user-quests/{id}/` (reflection, rating)
- `DELETE /api/user-quests/{id}/` (now allowed for completed)

## Testing
1. **In Progress** tab:
   - Click **Complete** → submit reflection (required) + rating (0.5 steps) → item moves to **Completed** only.
   - Click **Cancel** → confirm → removed.
2. **Completed** tab:
   - Click **Edit** → adjust reflection/rating → saved.
   - Click **Delete** → confirm → removed.

