### PR TITLE
Feat: Server-side photo upload for User Quest completion.

### DIFF
--- a/src/app/my-quests/page.tsx
+++ b/src/app/my-quests/page.tsx
@@ -1,18 +1,690 @@
+// "use client";
+
+// import { useEffect, useMemo, useState } from "react";
+// import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+// import {
+//   listMyUserQuests,
+//   completeUserQuest,
+//   deleteUserQuest,
+//   UserQuest,
+//   UserQuestCompleteBody,
+//   getAuthToken,
+// } from "@/lib/api";
+
+// const BACKEND_URL =
+//   process.env.NEXT_PUBLIC_BACKEND_URL || "http://127.0.0.1:8000";
+
+// async function patchUserQuestLocal(
+//   id: number,
+//   body: { reflection?: string; rating?: number }
+// ): Promise<UserQuest> {
+//   const token = getAuthToken();
+//   const res = await fetch(`${BACKEND_URL}/api/user-quests/${id}/`, {
+//     method: "PATCH",
+//     headers: {
+//       "Content-Type": "application/json",
+//       ...(token ? { Authorization: `Token ${token}` } : {}),
+//     },
+//     body: JSON.stringify(body),
+//   });
+//   if (!res.ok) {
+//     const text = await res.text().catch(() => "");
+//     throw new Error(text || `Request failed: ${res.status}`);
+//   }
+//   return res.json();
+// }
+
+// export default function MyQuestsPage() {
+//   const qc = useQueryClient();
+
+//   const [hasToken, setHasToken] = useState(false);
+//   useEffect(() => setHasToken(!!getAuthToken()), []);
+
+//   const { data, isLoading, error } = useQuery<UserQuest[]>({
+//     queryKey: ["my-user-quests"],
+//     queryFn: listMyUserQuests,
+//     enabled: hasToken,
+//   });
+
+//   const [tab, setTab] = useState<"inprogress" | "completed">("inprogress");
+
+//   const inProgress = useMemo(
+//     () => (data ?? []).filter((u) => !u.completed),
+//     [data]
+//   );
+//   const completed = useMemo(
+//     () => (data ?? []).filter((u) => u.completed),
+//     [data]
+//   );
+
+//   const [completeOpen, setCompleteOpen] = useState(false);
+//   const [activeUQ, setActiveUQ] = useState<UserQuest | null>(null);
+
+//   const completeMut = useMutation({
+//     mutationFn: ({ id, body }: { id: number; body: UserQuestCompleteBody }) =>
+//       completeUserQuest(id, body),
+//     onSuccess: () => {
+//       qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+//       setCompleteOpen(false);
+//       setActiveUQ(null);
+//     },
+//   });
+
+//   const [editOpen, setEditOpen] = useState(false);
+//   const [editingUQ, setEditingUQ] = useState<UserQuest | null>(null);
+
+//   const editMut = useMutation({
+//     mutationFn: ({ id, body }: { id: number; body: { reflection?: string; rating?: number } }) =>
+//       patchUserQuestLocal(id, body),
+//     onSuccess: () => {
+//       qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+//       setEditOpen(false);
+//       setEditingUQ(null);
+//     },
+//   });
+
+//   const [confirmOpen, setConfirmOpen] = useState(false);
+//   const [toDelete, setToDelete] = useState<UserQuest | null>(null);
+
+//   const deleteMut = useMutation({
+//     mutationFn: (id: number) => deleteUserQuest(id),
+//     onSuccess: () => {
+//       qc.invalidateQueries({ queryKey: ["my-user-quests"] });
+//       setConfirmOpen(false);
+//       setToDelete(null);
+//     },
+//   });
+
+//   if (!hasToken) {
+//     return (
+//       <main className="p-6">
+//         <h1 className="text-2xl font-bold mb-4">My Quests</h1>
+//         <div className="rounded-2xl border p-4 bg-white">Log in to see your quests.</div>
+//       </main>
+//     );
+//   }
+
+//   return (
+//     <main className="p-6 space-y-4">
+//       <div className="flex items-center justify-between">
+//         <h1 className="text-2xl font-bold">My Quests</h1>
+//         <div className="inline-flex rounded-xl border bg-white overflow-hidden">
+//           <button
+//             onClick={() => setTab("inprogress")}
+//             className={`px-4 py-2 text-sm ${tab === "inprogress" ? "bg-emerald-600 text-white" : "bg-white"}`}
+//           >
+//             In Progress ({inProgress.length})
+//           </button>
+//           <button
+//             onClick={() => setTab("completed")}
+//             className={`px-4 py-2 text-sm ${tab === "completed" ? "bg-emerald-600 text-white" : "bg-white"}`}
+//           >
+//             Completed ({completed.length})
+//           </button>
+//         </div>
+//       </div>
+
+//       {isLoading && <div>Loading your quests…</div>}
+//       {error && <div className="rounded-2xl border p-4 bg-white">Couldn’t load your quests.</div>}
+
+//       {!isLoading && !error && (
+//         <>
+//           {tab === "inprogress" ? (
+//             <InProgressList
+//               items={inProgress}
+//               onOpenComplete={(u) => {
+//                 setActiveUQ(u);
+//                 setCompleteOpen(true);
+//               }}
+//               onOpenCancel={(u) => {
+//                 setToDelete(u);
+//                 setConfirmOpen(true);
+//               }}
+//               deletingId={toDelete?.id}
+//               isDeleting={deleteMut.isPending}
+//             />
+//           ) : (
+//             <CompletedList
+//               items={completed}
+//               onOpenEdit={(u) => {
+//                 setEditingUQ(u);
+//                 setEditOpen(true);
+//               }}
+//               onOpenDelete={(u) => {
+//                 setToDelete(u);
+//                 setConfirmOpen(true);
+//               }}
+//               deletingId={toDelete?.id}
+//               isDeleting={deleteMut.isPending}
+//             />
+//           )}
+//         </>
+//       )}
+
+//       <CompleteModal
+//         open={completeOpen}
+//         onClose={() => {
+//           if (!completeMut.isPending) {
+//             setCompleteOpen(false);
+//             setActiveUQ(null);
+//           }
+//         }}
+//         uq={activeUQ}
+//         onSubmit={(body) => {
+//           if (!activeUQ) return;
+//           completeMut.mutate({ id: activeUQ.id, body });
+//         }}
+//         submitting={completeMut.isPending}
+//         errorMsg={(completeMut.error as any)?.message}
+//       />
+
+//       <EditCompletedModal
+//         open={editOpen}
+//         onClose={() => {
+//           if (!editMut.isPending) {
+//             setEditOpen(false);
+//             setEditingUQ(null);
+//           }
+//         }}
+//         uq={editingUQ}
+//         onSubmit={(body) => {
+//           if (!editingUQ) return;
+//           editMut.mutate({ id: editingUQ.id, body });
+//         }}
+//         submitting={editMut.isPending}
+//         errorMsg={(editMut.error as any)?.message}
+//       />
+
+//       <ConfirmModal
+//         open={confirmOpen}
+//         title="Remove this quest?"
+//         body="This will delete the quest from your list."
+//         confirmText={deleteMut.isPending ? "Deleting…" : "Yes, delete it"}
+//         cancelText="Nevermind"
+//         onCancel={() => {
+//           if (!deleteMut.isPending) {
+//             setConfirmOpen(false);
+//             setToDelete(null);
+//           }
+//         }}
+//         onConfirm={() => {
+//           if (toDelete) deleteMut.mutate(toDelete.id);
+//         }}
+//       />
+//     </main>
+//   );
+// }
+
+// /* === Lists === */
+
+// function InProgressList({
+//   items,
+//   onOpenComplete,
+//   onOpenCancel,
+//   isDeleting,
+//   deletingId,
+// }: {
+//   items: UserQuest[];
+//   onOpenComplete: (u: UserQuest) => void;
+//   onOpenCancel: (u: UserQuest) => void;
+//   isDeleting: boolean;
+//   deletingId?: number;
+// }) {
+//   if (!items.length) {
+//     return <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">No quests in progress yet.</div>;
+//   }
+
+//   return (
+//     <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+//       {items.map((u) => {
+//         const deleting = isDeleting && deletingId === u.id;
+//         return (
+//           <li key={u.id} className="relative rounded-2xl shadow p-4 bg-white space-y-3">
+//             <div className="absolute top-3 right-3 flex gap-2">
+//               <button
+//                 className="px-3 py-1 rounded-xl bg-emerald-600 text-white"
+//                 onClick={() => onOpenComplete(u)}
+//               >
+//                 Complete
+//               </button>
+//               <button
+//                 className="px-3 py-1 rounded-xl bg-red-100"
+//                 onClick={() => onOpenCancel(u)}
+//                 disabled={deleting}
+//                 title="Cancel this in-progress quest"
+//               >
+//                 {deleting ? "Deleting…" : "Cancel"}
+//               </button>
+//             </div>
+
+//             <div className="flex items-center gap-3 pr-28 md:pr-40">
+//               {/* eslint-disable-next-line @next/next/no-img-element */}
+//               {u.quest?.icon?.icon_url && (
+//                 <img src={u.quest.icon.icon_url} alt={u.quest.icon.name} className="h-8 w-8" />
+//               )}
+//               <div>
+//                 <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
+//                 <p className="text-sm text-gray-500">
+//                   {u.quest?.category?.name} · {u.quest?.difficulty?.name}
+//                 </p>
+//               </div>
+//             </div>
+
+//             <p className="text-sm text-gray-700">{u.quest?.description}</p>
+
+//             {!!u.quest?.tags?.length && (
+//               <div className="flex flex-wrap gap-2">
+//                 {u.quest.tags.map((t) => (
+//                   <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
+//                     #{t.name}
+//                   </span>
+//                 ))}
+//               </div>
+//             )}
+//           </li>
+//         );
+//       })}
+//     </ul>
+//   );
+// }
+
+// function CompletedList({
+//   items,
+//   onOpenEdit,
+//   onOpenDelete,
+//   isDeleting,
+//   deletingId,
+// }: {
+//   items: UserQuest[];
+//   onOpenEdit: (u: UserQuest) => void;
+//   onOpenDelete: (u: UserQuest) => void;
+//   isDeleting: boolean;
+//   deletingId?: number;
+// }) {
+//   if (!items.length) {
+//     return <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">No completed quests yet.</div>;
+//   }
+
+//   return (
+//     <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+//       {items.map((u) => {
+//         const deleting = isDeleting && deletingId === u.id;
+//         return (
+//           <li key={u.id} className="relative rounded-2xl shadow p-4 bg-white space-y-3">
+//             <div className="absolute top-3 right-3 flex gap-2">
+//               <button
+//                 className="px-3 py-1 rounded-xl bg-gray-100"
+//                 onClick={() => onOpenEdit(u)}
+//                 title="Edit reflection & rating"
+//               >
+//                 Edit
+//               </button>
+//               <button
+//                 className="px-3 py-1 rounded-xl bg-red-100"
+//                 onClick={() => onOpenDelete(u)}
+//                 disabled={deleting}
+//                 title="Delete this completed quest"
+//               >
+//                 {deleting ? "Deleting…" : "Delete"}
+//               </button>
+//             </div>
+
+//             <div className="flex items-center gap-3 pr-28 md:pr-40">
+//               {/* eslint-disable-next-line @next/next/no-img-element */}
+//               {u.quest?.icon?.icon_url && (
+//                 <img src={u.quest.icon.icon_url} alt={u.quest.icon.name} className="h-8 w-8" />
+//               )}
+//               <div>
+//                 <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
+//                 <p className="text-sm text-gray-500">
+//                   {u.quest?.category?.name} · {u.quest?.difficulty?.name}
+//                 </p>
+//               </div>
+//             </div>
+
+//             <p className="text-sm text-gray-700">{u.quest?.description}</p>
+
+//             {!!u.quest?.tags?.length && (
+//               <div className="flex flex-wrap gap-2">
+//                 {u.quest.tags.map((t) => (
+//                   <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
+//                     #{t.name}
+//                   </span>
+//                 ))}
+//               </div>
+//             )}
+
+//             {u.photo_url && (
+//               // eslint-disable-next-line @next/next/no-img-element
+//               <img
+//                 src={u.photo_url}
+//                 alt="Proof"
+//                 className="w-full max-h-56 object-cover rounded-xl border"
+//               />
+//             )}
+
+//             <div className="text-xs text-gray-500">
+//               {u.completed_at ? (
+//                 <span>Completed: {new Date(u.completed_at).toLocaleString()}</span>
+//               ) : (
+//                 <span>Completed</span>
+//               )}
+//               {u.rating != null && <span className="ml-2">• Rating: {String(u.rating)}</span>}
+//             </div>
+
+//             {u.reflection && (
+//               <div className="rounded-xl bg-gray-50 border p-3">
+//                 <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+//                   Reflection
+//                 </div>
+//                 <p className="text-sm text-gray-800 whitespace-pre-wrap">{u.reflection}</p>
+//               </div>
+//             )}
+//           </li>
+//         );
+//       })}
+//     </ul>
+//   );
+// }
+
+// /* === Modals === */
+
+// function CompleteModal({
+//   open,
+//   onClose,
+//   uq,
+//   onSubmit,
+//   submitting,
+//   errorMsg,
+// }: {
+//   open: boolean;
+//   onClose: () => void;
+//   uq: UserQuest | null;
+//   onSubmit: (body: UserQuestCompleteBody) => void;
+//   submitting: boolean;
+//   errorMsg?: string;
+// }) {
+//   const [reflection, setReflection] = useState("");
+//   const [rating, setRating] = useState("4.5");
+//   const [photoUrl, setPhotoUrl] = useState("");
+//   const [completedAt, setCompletedAt] = useState("");
+
+//   useEffect(() => {
+//     if (open) {
+//       setReflection("");
+//       setRating("4.5");
+//       setPhotoUrl("");
+//       setCompletedAt("");
+//     }
+//   }, [open]);
+
+//   useEffect(() => {
+//     if (!open) return;
+//     const onKey = (e: KeyboardEvent) => {
+//       if (e.key === "Escape") onClose();
+//     };
+//     window.addEventListener("keydown", onKey);
+//     return () => window.removeEventListener("keydown", onKey);
+//   }, [open, onClose]);
+
+//   if (!open || !uq) return null;
+
+//   return (
+//     <div className="fixed inset-0 z-50">
+//       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+//       <div className="absolute inset-0 flex items-center justify-center p-4">
+//         <div className="w-full max-w-xl rounded-2xl bg-white shadow-xl p-4">
+//           <div className="flex items-center justify-between mb-2">
+//             <h2 className="text-lg font-semibold">
+//               Complete: <span className="font-normal">{uq.quest?.title}</span>
+//             </h2>
+//             <button onClick={onClose} aria-label="Close" className="p-2 rounded hover:bg-gray-100">
+//               ✕
+//             </button>
+//           </div>
+
+//           <form
+//             className="space-y-4"
+//             onSubmit={(e) => {
+//               e.preventDefault();
+//               onSubmit({
+//                 reflection: reflection.trim(),
+//                 rating: Number(rating),
+//                 photo_url: photoUrl.trim() || undefined,
+//                 completed_at: completedAt.trim() || undefined,
+//               });
+//             }}
+//           >
+//             <label className="block">
+//               <span className="text-sm text-gray-600">Reflection *</span>
+//               <textarea
+//                 className="w-full border rounded-xl px-3 py-2"
+//                 rows={3}
+//                 value={reflection}
+//                 onChange={(e) => setReflection(e.target.value)}
+//                 required
+//               />
+//             </label>
+
+//             <div className="grid gap-3 md:grid-cols-3">
+//               <label className="block">
+//                 <span className="text-sm text-gray-600">Rating *</span>
+//                 <input
+//                   type="number"
+//                   step="0.5"
+//                   min="1"
+//                   max="5"
+//                   className="w-full border rounded-xl px-3 py-2"
+//                   value={rating}
+//                   onChange={(e) => setRating(e.target.value)}
+//                   required
+//                 />
+//               </label>
+//               <label className="block md:col-span-2">
+//                 <span className="text-sm text-gray-600">Photo URL (optional)</span>
+//                 <input
+//                   className="w-full border rounded-xl px-3 py-2"
+//                   value={photoUrl}
+//                   onChange={(e) => setPhotoUrl(e.target.value)}
+//                   placeholder="https://…"
+//                 />
+//               </label>
+//             </div>
+
+//             <label className="block">
+//               <span className="text-sm text-gray-600">Completed At</span>
+//               <input
+//                 className="w-full border rounded-xl px-3 py-2"
+//                 value={completedAt}
+//                 onChange={(e) => setCompletedAt(e.target.value)}
+//                 placeholder="2025-08-13T10:30:00-05:00"
+//               />
+//             </label>
+
+//             {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
+
+//             <div className="flex justify-end gap-2">
+//               <button type="button" className="px-4 py-2 rounded-xl bg-gray-100" onClick={onClose} disabled={submitting}>
+//                 Cancel
+//               </button>
+//               <button type="submit" className="px-4 py-2 rounded-xl bg-emerald-600 text-white" disabled={submitting}>
+//                 {submitting ? "Submitting…" : "Mark Complete"}
+//               </button>
+//             </div>
+//           </form>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
+// function EditCompletedModal({
+//   open,
+//   onClose,
+//   uq,
+//   onSubmit,
+//   submitting,
+//   errorMsg,
+// }: {
+//   open: boolean;
+//   onClose: () => void;
+//   uq: UserQuest | null;
+//   onSubmit: (body: { reflection?: string; rating?: number }) => void;
+//   submitting: boolean;
+//   errorMsg?: string;
+// }) {
+//   const [reflection, setReflection] = useState("");
+//   const [rating, setRating] = useState("0.0");
+
+//   useEffect(() => {
+//     if (open && uq) {
+//       setReflection(uq.reflection || "");
+//       setRating(uq.rating != null ? String(uq.rating) : "0.0");
+//     }
+//   }, [open, uq]);
+
+//   useEffect(() => {
+//     if (!open) return;
+//     const onKey = (e: KeyboardEvent) => {
+//       if (e.key === "Escape") onClose();
+//     };
+//     window.addEventListener("keydown", onKey);
+//     return () => window.removeEventListener("keydown", onKey);
+//   }, [open, onClose]);
+
+//   if (!open || !uq) return null;
+
+//   return (
+//     <div className="fixed inset-0 z-50">
+//       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+//       <div className="absolute inset-0 flex items-center justify-center p-4">
+//         <div className="w-full max-w-xl rounded-2xl bg-white shadow-xl p-4">
+//           <div className="flex items-center justify-between mb-2">
+//             <h2 className="text-lg font-semibold">
+//               Edit: <span className="font-normal">{uq.quest?.title}</span>
+//             </h2>
+//             <button onClick={onClose} aria-label="Close" className="p-2 rounded hover:bg-gray-100">
+//               ✕
+//             </button>
+//           </div>
+
+//           <form
+//             className="space-y-4"
+//             onSubmit={(e) => {
+//               e.preventDefault();
+//               onSubmit({
+//                 reflection: reflection.trim(),
+//                 rating: Number(rating),
+//               });
+//             }}
+//           >
+//             <label className="block">
+//               <span className="text-sm text-gray-600">Reflection *</span>
+//               <textarea
+//                 className="w-full border rounded-xl px-3 py-2"
+//                 rows={3}
+//                 value={reflection}
+//                 onChange={(e) => setReflection(e.target.value)}
+//                 required
+//               />
+//             </label>
+
+//             <label className="block">
+//               <span className="text-sm text-gray-600">Rating *</span>
+//               <input
+//                 type="number"
+//                 step="0.5"
+//                 min="1"
+//                 max="5"
+//                 className="w-full border rounded-xl px-3 py-2"
+//                 value={rating}
+//                 onChange={(e) => setRating(e.target.value)}
+//                 required
+//               />
+//             </label>
+
+//             {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
+
+//             <div className="flex justify-end gap-2">
+//               <button type="button" className="px-4 py-2 rounded-xl bg-gray-100" onClick={onClose} disabled={submitting}>
+//                 Cancel
+//               </button>
+//               <button type="submit" className="px-4 py-2 rounded-xl bg-emerald-600 text-white" disabled={submitting}>
+//                 {submitting ? "Saving…" : "Save Changes"}
+//               </button>
+//             </div>
+//           </form>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
+// function ConfirmModal({
+//   open,
+//   title,
+//   body,
+//   confirmText,
+//   cancelText,
+//   onConfirm,
+//   onCancel,
+// }: {
+//   open: boolean;
+//   title: string;
+//   body?: string;
+//   confirmText: string;
+//   cancelText: string;
+//   onConfirm: () => void;
+//   onCancel: () => void;
+// }) {
+//   useEffect(() => {
+//     if (!open) return;
+//     const onKey = (e: KeyboardEvent) => {
+//       if (e.key === "Escape") onCancel();
+//     };
+//     window.addEventListener("keydown", onKey);
+//     return () => window.removeEventListener("keydown", onKey);
+//   }, [open, onCancel]);
+
+//   if (!open) return null;
+
+//   return (
+//     <div className="fixed inset-0 z-50">
+//       <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
+//       <div className="absolute inset-0 flex items-center justify-center p-4">
+//         <div className="w-full max-w-md rounded-2xl bg-white shadow-xl p-4">
+//           <h3 className="text-lg font-semibold mb-2">{title}</h3>
+//           {body && <p className="text-sm text-gray-600 mb-4">{body}</p>}
+//           <div className="flex justify-end gap-2">
+//             <button className="px-4 py-2 rounded-xl bg-gray-100" onClick={onCancel}>
+//               {cancelText}
+//             </button>
+//             <button className="px-4 py-2 rounded-xl bg-red-600 text-white" onClick={onConfirm}>
+//               {confirmText}
+//             </button>
+//           </div>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   listMyUserQuests,
-  completeUserQuest,
   deleteUserQuest,
   UserQuest,
-  UserQuestCompleteBody,
   getAuthToken,
 } from "@/lib/api";
+import { completeUserQuestUpload } from "@/lib/api";
 
 const BACKEND_URL =
   process.env.NEXT_PUBLIC_BACKEND_URL || "http://127.0.0.1:8000";
+
+/* ---------- tiny helpers ---------- */
 
 async function patchUserQuestLocal(
   id: number,
@@ -34,6 +706,12 @@ async function patchUserQuestLocal(
   return res.json();
 }
 
+function getPhotoUrl(u: UserQuest): string | undefined {
+  return (u as any).photo || (u as any).photo_url || undefined;
+}
+
+/* ---------- page ---------- */
+
 export default function MyQuestsPage() {
   const qc = useQueryClient();
 
@@ -48,21 +726,20 @@ export default function MyQuestsPage() {
 
   const [tab, setTab] = useState<"inprogress" | "completed">("inprogress");
 
-  const inProgress = useMemo(
-    () => (data ?? []).filter((u) => !u.completed),
-    [data]
-  );
-  const completed = useMemo(
-    () => (data ?? []).filter((u) => u.completed),
-    [data]
-  );
+  const inProgress = useMemo(() => (data ?? []).filter((u) => !u.completed), [data]);
+  const completed = useMemo(() => (data ?? []).filter((u) => u.completed), [data]);
 
   const [completeOpen, setCompleteOpen] = useState(false);
   const [activeUQ, setActiveUQ] = useState<UserQuest | null>(null);
 
   const completeMut = useMutation({
-    mutationFn: ({ id, body }: { id: number; body: UserQuestCompleteBody }) =>
-      completeUserQuest(id, body),
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: number;
+      body: { reflection: string; rating: number; photo: File; completed_at?: string };
+    }) => completeUserQuestUpload(id, body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["my-user-quests"] });
       setCompleteOpen(false);
@@ -74,8 +751,13 @@ export default function MyQuestsPage() {
   const [editingUQ, setEditingUQ] = useState<UserQuest | null>(null);
 
   const editMut = useMutation({
-    mutationFn: ({ id, body }: { id: number; body: { reflection?: string; rating?: number } }) =>
-      patchUserQuestLocal(id, body),
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: number;
+      body: { reflection?: string; rating?: number };
+    }) => patchUserQuestLocal(id, body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["my-user-quests"] });
       setEditOpen(false);
@@ -95,6 +777,17 @@ export default function MyQuestsPage() {
     },
   });
 
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+
+   useEffect(() => {
+    if (!previewSrc) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPreviewSrc(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [previewSrc]);
+
   if (!hasToken) {
     return (
       <main className="p-6">
@@ -111,13 +804,17 @@ export default function MyQuestsPage() {
         <div className="inline-flex rounded-xl border bg-white overflow-hidden">
           <button
             onClick={() => setTab("inprogress")}
-            className={`px-4 py-2 text-sm ${tab === "inprogress" ? "bg-emerald-600 text-white" : "bg-white"}`}
+            className={`px-4 py-2 text-sm ${
+              tab === "inprogress" ? "bg-emerald-600 text-white" : "bg-white"
+            }`}
           >
             In Progress ({inProgress.length})
           </button>
           <button
             onClick={() => setTab("completed")}
-            className={`px-4 py-2 text-sm ${tab === "completed" ? "bg-emerald-600 text-white" : "bg-white"}`}
+            className={`px-4 py-2 text-sm ${
+              tab === "completed" ? "bg-emerald-600 text-white" : "bg-white"
+            }`}
           >
             Completed ({completed.length})
           </button>
@@ -154,6 +851,7 @@ export default function MyQuestsPage() {
                 setToDelete(u);
                 setConfirmOpen(true);
               }}
+              onPreview={(src) => setPreviewSrc(src)}
               deletingId={toDelete?.id}
               isDeleting={deleteMut.isPending}
             />
@@ -211,11 +909,80 @@ export default function MyQuestsPage() {
           if (toDelete) deleteMut.mutate(toDelete.id);
         }}
       />
+
+           {previewSrc && (
+        <div className="fixed inset-0 z-[100]">
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/70"
+            onClick={() => setPreviewSrc(null)}
+            aria-hidden="true"
+          />
+          {/* Close button */}
+          <button
+            type="button"
+            aria-label="Close image preview"
+            className="absolute top-4 right-4 z-[110] rounded-full bg-white/90 hover:bg-white p-2 shadow"
+            onClick={() => setPreviewSrc(null)}
+          >
+            ✕
+          </button>
+          {/* Image */}
+          <div className="absolute inset-0 z-[105] flex items-center justify-center p-4">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={previewSrc}
+              alt="Preview"
+              className="max-h-[85vh] max-w-[90vw] rounded-xl shadow-2xl cursor-zoom-out"
+              onClick={() => setPreviewSrc(null)}
+            />
+          </div>
+        </div>
+      )}
+
     </main>
   );
 }
 
-/* === Lists === */
+/* === shared bits === */
+
+function QuestHeader({
+  uq,
+  padRight = "pr-28 md:pr-40",
+}: {
+  uq: UserQuest;
+  padRight?: string;
+}) {
+  return (
+    <div className={`flex items-center gap-3 ${padRight}`}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      {uq.quest?.icon?.icon_url && (
+        <img src={uq.quest.icon.icon_url} alt={uq.quest.icon.name} className="h-8 w-8" />
+      )}
+      <div>
+        <h2 className="text-lg font-semibold">{uq.quest?.title}</h2>
+        <p className="text-sm text-gray-500">
+          {uq.quest?.category?.name} · {uq.quest?.difficulty?.name}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function TagChips({ uq }: { uq: UserQuest }) {
+  if (!uq.quest?.tags?.length) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {uq.quest.tags.map((t) => (
+        <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
+          #{t.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* === lists === */
 
 function InProgressList({
   items,
@@ -231,7 +998,11 @@ function InProgressList({
   deletingId?: number;
 }) {
   if (!items.length) {
-    return <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">No quests in progress yet.</div>;
+    return (
+      <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">
+        No quests in progress yet.
+      </div>
+    );
   }
 
   return (
@@ -257,30 +1028,9 @@ function InProgressList({
               </button>
             </div>
 
-            <div className="flex items-center gap-3 pr-28 md:pr-40">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              {u.quest?.icon?.icon_url && (
-                <img src={u.quest.icon.icon_url} alt={u.quest.icon.name} className="h-8 w-8" />
-              )}
-              <div>
-                <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
-                <p className="text-sm text-gray-500">
-                  {u.quest?.category?.name} · {u.quest?.difficulty?.name}
-                </p>
-              </div>
-            </div>
-
+            <QuestHeader uq={u} />
             <p className="text-sm text-gray-700">{u.quest?.description}</p>
-
-            {!!u.quest?.tags?.length && (
-              <div className="flex flex-wrap gap-2">
-                {u.quest.tags.map((t) => (
-                  <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
-                    #{t.name}
-                  </span>
-                ))}
-              </div>
-            )}
+            <TagChips uq={u} />
           </li>
         );
       })}
@@ -292,23 +1042,30 @@ function CompletedList({
   items,
   onOpenEdit,
   onOpenDelete,
+  onPreview,
   isDeleting,
   deletingId,
 }: {
   items: UserQuest[];
   onOpenEdit: (u: UserQuest) => void;
   onOpenDelete: (u: UserQuest) => void;
+  onPreview: (src: string) => void;
   isDeleting: boolean;
   deletingId?: number;
 }) {
   if (!items.length) {
-    return <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">No completed quests yet.</div>;
+    return (
+      <div className="rounded-2xl border p-6 text-sm text-gray-600 bg-white">
+        No completed quests yet.
+      </div>
+    );
   }
 
   return (
     <ul className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
       {items.map((u) => {
         const deleting = isDeleting && deletingId === u.id;
+        const photo = getPhotoUrl(u);
         return (
           <li key={u.id} className="relative rounded-2xl shadow p-4 bg-white space-y-3">
             <div className="absolute top-3 right-3 flex gap-2">
@@ -329,37 +1086,17 @@ function CompletedList({
               </button>
             </div>
 
-            <div className="flex items-center gap-3 pr-28 md:pr-40">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              {u.quest?.icon?.icon_url && (
-                <img src={u.quest.icon.icon_url} alt={u.quest.icon.name} className="h-8 w-8" />
-              )}
-              <div>
-                <h2 className="text-lg font-semibold">{u.quest?.title}</h2>
-                <p className="text-sm text-gray-500">
-                  {u.quest?.category?.name} · {u.quest?.difficulty?.name}
-                </p>
-              </div>
-            </div>
-
+            <QuestHeader uq={u} />
             <p className="text-sm text-gray-700">{u.quest?.description}</p>
+            <TagChips uq={u} />
 
-            {!!u.quest?.tags?.length && (
-              <div className="flex flex-wrap gap-2">
-                {u.quest.tags.map((t) => (
-                  <span key={t.id} className="text-xs bg-gray-100 px-2 py-1 rounded-full">
-                    #{t.name}
-                  </span>
-                ))}
-              </div>
-            )}
-
-            {u.photo_url && (
+            {photo && (
               // eslint-disable-next-line @next/next/no-img-element
               <img
-                src={u.photo_url}
+                src={photo}
                 alt="Proof"
-                className="w-full max-h-56 object-cover rounded-xl border"
+                className="max-w-80 max-h-40 object-cover rounded-xl border cursor-zoom-in"
+                onClick={() => onPreview(photo)}
               />
             )}
 
@@ -374,9 +1111,7 @@ function CompletedList({
 
             {u.reflection && (
               <div className="rounded-xl bg-gray-50 border p-3">
-                <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">
-                  Your reflection
-                </div>
+                <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Reflection</div>
                 <p className="text-sm text-gray-800 whitespace-pre-wrap">{u.reflection}</p>
               </div>
             )}
@@ -387,7 +1122,7 @@ function CompletedList({
   );
 }
 
-/* === Modals === */
+/* === modals === */
 
 function CompleteModal({
   open,
@@ -400,20 +1135,20 @@ function CompleteModal({
   open: boolean;
   onClose: () => void;
   uq: UserQuest | null;
-  onSubmit: (body: UserQuestCompleteBody) => void;
+  onSubmit: (body: { reflection: string; rating: number; photo: File; completed_at?: string }) => void;
   submitting: boolean;
   errorMsg?: string;
 }) {
   const [reflection, setReflection] = useState("");
   const [rating, setRating] = useState("4.5");
-  const [photoUrl, setPhotoUrl] = useState("");
+  const [file, setFile] = useState<File | null>(null);
   const [completedAt, setCompletedAt] = useState("");
 
   useEffect(() => {
     if (open) {
       setReflection("");
       setRating("4.5");
-      setPhotoUrl("");
+      setFile(null);
       setCompletedAt("");
     }
   }, [open]);
@@ -447,10 +1182,14 @@ function CompleteModal({
             className="space-y-4"
             onSubmit={(e) => {
               e.preventDefault();
+              if (!file) {
+                alert("Please choose an image.");
+                return;
+              }
               onSubmit({
                 reflection: reflection.trim(),
                 rating: Number(rating),
-                photo_url: photoUrl.trim() || undefined,
+                photo: file,
                 completed_at: completedAt.trim() || undefined,
               });
             }}
@@ -481,33 +1220,43 @@ function CompleteModal({
                 />
               </label>
               <label className="block md:col-span-2">
-                <span className="text-sm text-gray-600">Photo URL (optional)</span>
+                <span className="text-sm text-gray-600">Photo *</span>
                 <input
+                  type="file"
+                  accept="image/*"
                   className="w-full border rounded-xl px-3 py-2"
-                  value={photoUrl}
-                  onChange={(e) => setPhotoUrl(e.target.value)}
-                  placeholder="https://…"
+                  onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                  required
                 />
               </label>
             </div>
 
             <label className="block">
-              <span className="text-sm text-gray-600">Completed At</span>
+              <span className="text-sm text-gray-600">Completed At (optional)</span>
               <input
                 className="w-full border rounded-xl px-3 py-2"
                 value={completedAt}
                 onChange={(e) => setCompletedAt(e.target.value)}
-                placeholder="2025-08-13T10:30:00-05:00"
+                placeholder="2025-08-19T10:30:00-05:00"
               />
             </label>
 
             {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
 
             <div className="flex justify-end gap-2">
-              <button type="button" className="px-4 py-2 rounded-xl bg-gray-100" onClick={onClose} disabled={submitting}>
+              <button
+                type="button"
+                className="px-4 py-2 rounded-xl bg-gray-100"
+                onClick={onClose}
+                disabled={submitting}
+              >
                 Cancel
               </button>
-              <button type="submit" className="px-4 py-2 rounded-xl bg-emerald-600 text-white" disabled={submitting}>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-xl bg-emerald-600 text-white"
+                disabled={submitting}
+              >
                 {submitting ? "Submitting…" : "Mark Complete"}
               </button>
             </div>
@@ -534,12 +1283,12 @@ function EditCompletedModal({
   errorMsg?: string;
 }) {
   const [reflection, setReflection] = useState("");
-  const [rating, setRating] = useState("4.5");
+  const [rating, setRating] = useState("0.0");
 
   useEffect(() => {
     if (open && uq) {
       setReflection(uq.reflection || "");
-      setRating(uq.rating != null ? String(uq.rating) : "4.5");
+      setRating(uq.rating != null ? String(uq.rating) : "0.0");
     }
   }, [open, uq]);
 
@@ -606,10 +1355,19 @@ function EditCompletedModal({
             {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
 
             <div className="flex justify-end gap-2">
-              <button type="button" className="px-4 py-2 rounded-xl bg-gray-100" onClick={onClose} disabled={submitting}>
+              <button
+                type="button"
+                className="px-4 py-2 rounded-xl bg-gray-100"
+                onClick={onClose}
+                disabled={submitting}
+              >
                 Cancel
               </button>
-              <button type="submit" className="px-4 py-2 rounded-xl bg-emerald-600 text-white" disabled={submitting}>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded-xl bg-emerald-600 text-white"
+                disabled={submitting}
+              >
                 {submitting ? "Saving…" : "Save Changes"}
               </button>
             </div>

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -32,9 +32,9 @@ export default function NavBar() {
       <div className="mx-auto max-w-4xl px-4 py-3 flex items-center justify-between">
         <Link href="/" className="font-medium">EcoGrow</Link>
         <div className="flex items-center gap-4">
-          <Link href="/" className="hover:underline">Home</Link>
-          <Link href="/quests" className="px-3 py-2 rounded-xl hover:bg-gray-100">Quests</Link>
+          <Link href="/quests" className="px-3 py-2 rounded-xl hover:bg-gray-100">All Quests</Link>
           <Link href="/my-quests" className="px-3 py-2 rounded-xl hover:bg-gray-100"> My Quests</Link>
+          <Link href="/my-quests" className="px-3 py-2 rounded-xl hover:bg-gray-100"> Profile</Link>
           <button
             onClick={onLogout}
             className="rounded-md border px-3 py-1 text-sm"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,179 @@
+// // src/lib/api.ts
+// export const BACKEND_URL =
+//   process.env.NEXT_PUBLIC_BACKEND_URL || "http://127.0.0.1:8000";
+
+// const TOKEN_KEY = "EG_TOKEN"; 
+
+// export function getAuthToken(): string | null {
+//   if (typeof window === "undefined") return null;
+//   return localStorage.getItem(TOKEN_KEY);
+// }
+
+// function authHeaders() {
+//   const token = getAuthToken();
+//   return token ? { Authorization: `Token ${token}` } : {};
+// }
+
+// export async function fetchJSON<T>(path: string, options?: RequestInit): Promise<T> {
+//   // Build a Headers object so we can safely merge any HeadersInit type
+//   const headers = new Headers(options?.headers ?? {});
+//   headers.set("Content-Type", "application/json");
+
+//   // Merge auth header (if present)
+//   const auth = authHeaders();
+//   Object.entries(auth).forEach(([k, v]) => headers.set(k, v as string));
+
+//   const res = await fetch(`${BACKEND_URL}${path}`, {
+//     ...options,
+//     headers,
+//     cache: "no-store",
+//   });
+
+//   if (!res.ok) {
+//     const text = await res.text();
+//     throw new Error(`${res.status} ${text}`);
+//   }
+//   // 204 has no body
+//   return (res.status === 204 ? (null as T) : res.json()) as Promise<T>;
+// }
+
+
+// // ===== Types =====
+// export type Category = { id: number; name: string };
+// export type Icon = { id: number; name: string; icon_url: string };
+// export type Difficulty = { id: number; name: string };
+// export type Tag = { id: number; name: string };
+
+// export type Quest = {
+//   id: number;
+//   title: string;
+//   description: string;
+//   is_custom: boolean;
+//   category: Category;
+//   icon: Icon;
+//   difficulty: Difficulty;
+//   tags: Tag[];
+//   created_by: number;
+// };
+
+// export type QuestPatchBody = {
+//   title?: string;
+//   description?: string;
+//   is_custom?: boolean;
+//   category_id?: number;
+//   icon_id?: number;
+//   difficulty_id?: number;
+//   tag_ids?: number[];
+// };
+
+// export type Me = {
+//   id: number;
+//   username: string;
+//   email: string;
+//   profile_img?: string | null;
+//   date_joined?: string;
+// };
+
+// export type QuestCreateBody = {
+//   title: string;
+//   description: string;
+//   category_id: number;
+//   icon_id: number;
+//   difficulty_id: number;
+//   is_custom?: boolean;
+//   tag_ids?: number[]; // optional, up to 3 on the UI
+// };
+
+// // ===== UserQuest Types =====
+// export type UserQuest = {
+//   id: number;
+//   quest: Quest;                         // nested quest comes back from the API
+//   completed: boolean;
+//   completed_at: string | null;          // ISO string or null
+//   reflection: string;
+//   photo_url: string;
+//   rating: number | string | null;       // DRF may serialize Decimal as string
+// };
+
+// export type UserQuestCompleteBody = {
+//   reflection: string;                   // required
+//   rating: number;                       // 1–5 in 0.5 steps
+//   photo_url?: string;                   // optional
+//   completed_at?: string;                // optional ISO timestamp from client
+// };
+
+// // ===== UserQuest API (standalone exports) =====
+// // (Using standalone exports so you don't have to re-open the API object)
+// export const listMyUserQuests = () =>
+//   fetchJSON<UserQuest[]>("/api/user-quests/");
+
+// export const adoptUserQuest = (quest_id: number) =>
+//   fetchJSON<UserQuest>("/api/user-quests/", {
+//     method: "POST",
+//     body: JSON.stringify({ quest_id }),
+//   });
+
+// export const completeUserQuest = (id: number, body: UserQuestCompleteBody) =>
+//   fetchJSON<UserQuest>(`/api/user-quests/${id}/complete/`, {
+//     method: "POST",
+//     body: JSON.stringify(body),
+//   });
+
+// export const deleteUserQuest = (id: number) =>
+//   fetchJSON<void>(`/api/user-quests/${id}/`, { method: "DELETE" });
+
+
+// // ===== API surface =====
+// export const API = {
+//   me: () => fetchJSON<Me>("/api/auth/me/"),
+//   listQuests: () => fetchJSON<Quest[]>("/api/quests/"),
+//   listCategories: () => fetchJSON<Category[]>("/api/categories/"),
+//   listIcons: () => fetchJSON<Icon[]>("/api/icons/"),
+//   listDifficulties: () => fetchJSON<Difficulty[]>("/api/difficulties/"),
+//   listTags: () => fetchJSON<Tag[]>("/api/tags/"),
+//   patchQuest: (id: number, body: Partial<QuestPatchBody>) =>
+//     fetchJSON<Quest>(`/api/quests/${id}/`, { method: "PATCH", body: JSON.stringify(body) }),
+//   deleteQuest: (id: number) =>
+//     fetchJSON<void>(`/api/quests/${id}/`, { method: "DELETE" }),
+//     createQuest: (body: QuestCreateBody) =>
+//     fetchJSON<Quest>("/api/quests/", {
+//       method: "POST",
+//       body: JSON.stringify(body),
+//     }),
+// };
+
+// export async function completeUserQuestUpload(
+//   id: number,
+//   payload: { reflection: string; rating: number; photo: File; completed_at?: string }
+// ) {
+//   const form = new FormData();
+//   form.append("reflection", payload.reflection);
+//   form.append("rating", String(payload.rating));
+//   form.append("photo", payload.photo);
+//   if (payload.completed_at) form.append("completed_at", payload.completed_at);
+
+//   const token = getAuthToken?.() ?? null; // if getAuthToken is exported here
+//   const res = await fetch(`${BACKEND_URL}/api/user-quests/${id}/complete/`, {
+//     method: "POST",
+//     headers: token ? { Authorization: `Token ${token}` } : undefined, // DON'T set Content-Type
+//     body: form,
+//   });
+//   if (!res.ok) {
+//     const msg = await res.text().catch(() => "");
+//     throw new Error(msg || `Request failed: ${res.status}`);
+//   }
+//   return res.json();
+// }
+
+
 // src/lib/api.ts
+
 export const BACKEND_URL =
   process.env.NEXT_PUBLIC_BACKEND_URL || "http://127.0.0.1:8000";
 
-const TOKEN_KEY = "EG_TOKEN"; 
+const TOKEN_KEY = "EG_TOKEN";
 
+// ===== Auth Utilities =====
 export function getAuthToken(): string | null {
   if (typeof window === "undefined") return null;
   return localStorage.getItem(TOKEN_KEY);
@@ -14,14 +184,11 @@ function authHeaders() {
   return token ? { Authorization: `Token ${token}` } : {};
 }
 
+// Generic fetch for JSON APIs (auto-includes auth)
 export async function fetchJSON<T>(path: string, options?: RequestInit): Promise<T> {
-  // Build a Headers object so we can safely merge any HeadersInit type
   const headers = new Headers(options?.headers ?? {});
   headers.set("Content-Type", "application/json");
-
-  // Merge auth header (if present)
-  const auth = authHeaders();
-  Object.entries(auth).forEach(([k, v]) => headers.set(k, v as string));
+  Object.entries(authHeaders()).forEach(([k, v]) => headers.set(k, v as string));
 
   const res = await fetch(`${BACKEND_URL}${path}`, {
     ...options,
@@ -33,10 +200,24 @@ export async function fetchJSON<T>(path: string, options?: RequestInit): Promise
     const text = await res.text();
     throw new Error(`${res.status} ${text}`);
   }
-  // 204 has no body
   return (res.status === 204 ? (null as T) : res.json()) as Promise<T>;
 }
 
+// Generic fetch for FormData APIs (auto-includes auth, omits Content-Type)
+async function fetchForm<T>(path: string, form: FormData, options?: RequestInit): Promise<T> {
+  const headers: HeadersInit = { ...authHeaders() }; // Don't set Content-Type!
+  const res = await fetch(`${BACKEND_URL}${path}`, {
+    ...options,
+    method: options?.method || "POST",
+    headers,
+    body: form,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `Request failed: ${res.status}`);
+  }
+  return res.json();
+}
 
 // ===== Types =====
 export type Category = { id: number; name: string };
@@ -81,63 +262,89 @@ export type QuestCreateBody = {
   icon_id: number;
   difficulty_id: number;
   is_custom?: boolean;
-  tag_ids?: number[]; // optional, up to 3 on the UI
+  tag_ids?: number[];
 };
 
-// ===== UserQuest Types =====
 export type UserQuest = {
   id: number;
-  quest: Quest;                         // nested quest comes back from the API
+  quest: Quest;
   completed: boolean;
-  completed_at: string | null;          // ISO string or null
+  completed_at: string | null;
   reflection: string;
   photo_url: string;
-  rating: number | string | null;       // DRF may serialize Decimal as string
+  rating: number | string | null;
 };
 
 export type UserQuestCompleteBody = {
-  reflection: string;                   // required
-  rating: number;                       // 1–5 in 0.5 steps
-  photo_url?: string;                   // optional
-  completed_at?: string;                // optional ISO timestamp from client
+  reflection: string;
+  rating: number;
+  photo_url?: string;
+  completed_at?: string;
 };
-
-// ===== UserQuest API (standalone exports) =====
-// (Using standalone exports so you don't have to re-open the API object)
-export const listMyUserQuests = () =>
-  fetchJSON<UserQuest[]>("/api/user-quests/");
-
-export const adoptUserQuest = (quest_id: number) =>
-  fetchJSON<UserQuest>("/api/user-quests/", {
-    method: "POST",
-    body: JSON.stringify({ quest_id }),
-  });
-
-export const completeUserQuest = (id: number, body: UserQuestCompleteBody) =>
-  fetchJSON<UserQuest>(`/api/user-quests/${id}/complete/`, {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
-
-export const deleteUserQuest = (id: number) =>
-  fetchJSON<void>(`/api/user-quests/${id}/`, { method: "DELETE" });
-
 
 // ===== API surface =====
 export const API = {
+  // Auth & user
   me: () => fetchJSON<Me>("/api/auth/me/"),
+
+  // Quests
   listQuests: () => fetchJSON<Quest[]>("/api/quests/"),
-  listCategories: () => fetchJSON<Category[]>("/api/categories/"),
-  listIcons: () => fetchJSON<Icon[]>("/api/icons/"),
-  listDifficulties: () => fetchJSON<Difficulty[]>("/api/difficulties/"),
-  listTags: () => fetchJSON<Tag[]>("/api/tags/"),
+  createQuest: (body: QuestCreateBody) =>
+    fetchJSON<Quest>("/api/quests/", { method: "POST", body: JSON.stringify(body) }),
   patchQuest: (id: number, body: Partial<QuestPatchBody>) =>
     fetchJSON<Quest>(`/api/quests/${id}/`, { method: "PATCH", body: JSON.stringify(body) }),
   deleteQuest: (id: number) =>
     fetchJSON<void>(`/api/quests/${id}/`, { method: "DELETE" }),
-    createQuest: (body: QuestCreateBody) =>
-    fetchJSON<Quest>("/api/quests/", {
+
+  // Metadata
+  listCategories: () => fetchJSON<Category[]>("/api/categories/"),
+  listIcons: () => fetchJSON<Icon[]>("/api/icons/"),
+  listDifficulties: () => fetchJSON<Difficulty[]>("/api/difficulties/"),
+  listTags: () => fetchJSON<Tag[]>("/api/tags/"),
+
+  // UserQuests
+  listMyUserQuests: () => fetchJSON<UserQuest[]>("/api/user-quests/"),
+  adoptUserQuest: (quest_id: number) =>
+    fetchJSON<UserQuest>("/api/user-quests/", {
+      method: "POST",
+      body: JSON.stringify({ quest_id }),
+    }),
+  completeUserQuest: (id: number, body: UserQuestCompleteBody) =>
+    fetchJSON<UserQuest>(`/api/user-quests/${id}/complete/`, {
       method: "POST",
       body: JSON.stringify(body),
     }),
+  deleteUserQuest: (id: number) =>
+    fetchJSON<void>(`/api/user-quests/${id}/`, { method: "DELETE" }),
+
+  // UserQuest with file upload (reflection, rating, photo, completed_at)
+  completeUserQuestUpload: (
+    id: number,
+    payload: { reflection: string; rating: number; photo: File; completed_at?: string }
+  ) => {
+    const form = new FormData();
+    form.append("reflection", payload.reflection);
+    form.append("rating", String(payload.rating));
+    form.append("photo", payload.photo);
+    if (payload.completed_at) form.append("completed_at", payload.completed_at);
+    return fetchForm<UserQuest>(`/api/user-quests/${id}/complete/`, form);
+  },
 };
+
+// ====== Optionally, export API methods individually if needed ======
+export const {
+  me,
+  listQuests,
+  createQuest,
+  patchQuest,
+  deleteQuest,
+  listCategories,
+  listIcons,
+  listDifficulties,
+  listTags,
+  listMyUserQuests,
+  adoptUserQuest,
+  completeUserQuest,
+  deleteUserQuest,
+  completeUserQuestUpload,
+} = API;


### PR DESCRIPTION
# Display Completion Photos

## Feat: display uploaded completion photo (thumbnail + modal) and polish actions

## Summary
- `My Quests` (completed cards) now render the backend-provided `u.photo` as a thumbnail.
- Click-to-zoom modal added (ESC or ✕ closes).
- Moved action buttons (Complete/Cancel, Edit/Delete) to the **top-right** of cards and padded the title row to avoid overlap.
- Minor UX polish around loading/disabled states.
